### PR TITLE
Map "levels" to "floors" refactor

### DIFF
--- a/include/dummy/core/map.hpp
+++ b/include/dummy/core/map.hpp
@@ -39,7 +39,7 @@ public:
 class Project;
 
 class BlockingLayer;
-using BlockingLevels = std::vector<BlockingLayer>;
+using BlockingFloors = std::vector<BlockingLayer>;
 
 class Map {
 public:
@@ -71,7 +71,7 @@ protected:
 protected:
     std::string m_name;
     std::uint16_t m_width, m_height;
-    std::uint8_t m_levelsCount;
+    std::uint8_t m_floorsCount;
     void internalLoadMapFile(std::string);
 };
 

--- a/include/dummy/local/floor.hpp
+++ b/include/dummy/local/floor.hpp
@@ -15,9 +15,9 @@ class Map;
 
 using GraphicLayers = std::map<std::int8_t, Dummy::Core::GraphicLayer>;
 
-class Level {
+class Floor {
 public:
-    Level(const Map&);
+    Floor(const Map&);
     void addGraphicLayer(std::int8_t,
                          Dummy::Core::GraphicLayer&&);
     const Dummy::Core::GraphicLayer& graphicLayer(std::int8_t position) const {

--- a/include/dummy/local/map.hpp
+++ b/include/dummy/local/map.hpp
@@ -1,17 +1,17 @@
 #pragma once
 
 #include <dummy/core/map.hpp>
-#include <dummy/local/level.hpp>
+#include <dummy/local/floor.hpp>
 
 namespace Dummy
 {
 namespace Local
 {
 
-class Level;
+class Floor;
 class Project;
 
-using Levels = std::vector<Level>;
+using Floors = std::vector<Floor>;
 
 class Map : public Dummy::Core::Map {
 public:
@@ -28,18 +28,18 @@ public:
         return m_music;
     }
 
-    const Levels& levels() const {
-        return m_levels;
+    const Floors& floors() const {
+        return m_floors;
     }
 protected:
     void loadMapFile(std::ifstream&);
-    void readMapLevel(std::ifstream&, std::ifstream&);
+    void readMapFloor(std::ifstream&, std::ifstream&);
 
     const Project& m_project;
 
     std::string m_chipset;
     std::string m_music;
-    Levels m_levels;
+    Floors m_floors;
 };
 
 } // namespace Core

--- a/src/core/map.cpp
+++ b/src/core/map.cpp
@@ -16,7 +16,7 @@ namespace Core
 {
 
 Map::Map(const std::string& name) : m_name(name), m_width(1), m_height(1),
-    m_levelsCount(0)
+    m_floorsCount(0)
 {
 }
 
@@ -37,8 +37,8 @@ void Map::loadBaseInfo(std::ifstream& ifs) {
     std::cerr << m_name << " (" << m_width * 2 << "," << m_height * 2 << ")"
         << std::endl;
 
-    // read the number of levels
-    ifs.read(reinterpret_cast<char*>(&m_levelsCount), sizeof(std::uint8_t));
+    // read the number of floors
+    ifs.read(reinterpret_cast<char*>(&m_floorsCount), sizeof(std::uint8_t));
 }
 
 BlockingLayer Map::loadBlockingLayer(std::ifstream& ifs) {

--- a/src/local/floor.cpp
+++ b/src/local/floor.cpp
@@ -1,31 +1,31 @@
 #include <dummy/core/blocking_layer.hpp>
 #include <dummy/core/graphic_layer.hpp>
 #include <dummy/local/map.hpp>
-#include <dummy/local/level.hpp>
+#include <dummy/local/floor.hpp>
 
 
 namespace Dummy {
 namespace Local {
 
-Level::Level(const Map& map)
+Floor::Floor(const Map& map)
     : m_map(map), m_blockingLayer(m_map.width(), m_map.height()) {}
 
-void Level::addGraphicLayer(
+void Floor::addGraphicLayer(
     std::int8_t position,
     Dummy::Core::GraphicLayer&& layer
 ) {
     m_graphicLayers[position] = std::move(layer);
 }
 
-void Level::setBlockingLayer(Dummy::Core::BlockingLayer&& blockingLayer) {
+void Floor::setBlockingLayer(Dummy::Core::BlockingLayer&& blockingLayer) {
     m_blockingLayer = std::move(blockingLayer);
 }
 
-std::uint16_t Level::width() const {
+std::uint16_t Floor::width() const {
     return m_map.width();
 }
 
-std::uint16_t Level::height() const {
+std::uint16_t Floor::height() const {
     return m_map.height();
 }
 

--- a/src/local/map.cpp
+++ b/src/local/map.cpp
@@ -40,8 +40,8 @@ void Map::load() {
     loadMapFile(ifsMapFile);
     readBlkFile(ifsBlkFile);
 
-    for (int i = 0; i < m_levelsCount; ++i) {
-        readMapLevel(ifsMapFile, ifsBlkFile);
+    for (int i = 0; i < m_floorsCount; ++i) {
+        readMapFloor(ifsMapFile, ifsBlkFile);
     }
 }
 
@@ -71,11 +71,11 @@ void Map::loadMapFile(std::ifstream& ifs) {
     }
 }
 
-void Map::readMapLevel(
+void Map::readMapFloor(
     std::ifstream& ifsMapFile,
     std::ifstream& ifsBlkFile)
 {
-    Level level(*this);
+    Floor floor(*this);
     std::size_t elements = m_width * m_height;
     std::uint8_t layersCount;
 
@@ -99,14 +99,14 @@ void Map::readMapLevel(
                 elements * sizeof(std::pair<std::int8_t, std::int8_t>)
             )
         );
-        level.addGraphicLayer(position, std::move(graphicLayer));
+        floor.addGraphicLayer(position, std::move(graphicLayer));
     }
     // Read the blocking layer
     Dummy::Core::BlockingLayer&& blockingLayer = loadBlockingLayer(ifsBlkFile);
-    level.setBlockingLayer(std::move(blockingLayer));
+    floor.setBlockingLayer(std::move(blockingLayer));
 
-    // Create the level.
-    m_levels.push_back(std::move(level));
+    // Create the floor.
+    m_floors.push_back(std::move(floor));
 }
 
 } // namespace Core

--- a/src/remote/map.cpp
+++ b/src/remote/map.cpp
@@ -31,7 +31,7 @@ void Map::load() {
     Dummy::Core::Map::loadBaseInfo(ifsMapFile);
     readBlkFile(ifsBlkFile);
 
-    for (int i = 0; i < m_levelsCount; ++i) {
+    for (int i = 0; i < m_floorsCount; ++i) {
         m_floors.push_back(std::move(loadBlockingLayer(ifsBlkFile)));
     }
 


### PR DESCRIPTION
Refactored all references to map levels to floors inside the lib, so we can use the word level for other things without confusion